### PR TITLE
Add payu version to config and initial generate checksums workflow

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository != 'ACCESS-NRI/model-configs-template'
     runs-on: ubuntu-latest
     outputs:
-      python-version: ${{ steps.repro-config.outputs.python-version }}
+      payu-version: ${{ steps.repro-config.outputs.payu-version }}
       model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
     steps:
       - name: Checkout main
@@ -58,7 +58,7 @@ jobs:
     steps:
       - run: |
           echo '::notice::This deployment is using the following inputs: `config-branch-name`=`${{ inputs.config-branch-name }}`, `commit-checksums`=`${{ inputs.commit-checksums }}`, `committed-checksum-location`=`${{ inputs.committed-checksum-location }}`,`committed-checksum-tag-version`=`${{ inputs.committed-checksum-tag-version }}`.'
-          echo '::notice::This deployment is using Python Version ${{ needs.config.outputs.python-version }} and Model Config Tests Version ${{ needs.config.outputs.model-config-tests-version }}'
+          echo '::notice::This deployment is using Payu Version ${{ needs.config.outputs.payu-version }} and Model Config Tests Version ${{ needs.config.outputs.model-config-tests-version }}'
 
   generate-checksums:
     name: Generate Checksums
@@ -73,7 +73,7 @@ jobs:
       committed-checksum-tag: "${{ inputs.config-branch-name }}-${{ inputs.committed-checksum-tag-version }}"
       environment-name: "Gadi Initial Checksum"  # FIXME: This Environment doesn't nessecarily have to be called this
       model-config-tests-version: ${{ needs.config.outputs.model-config-tests-version }}
-      python-version: ${{ needs.config.outputs.python-version }}
+      payu-version: ${{ needs.config.outputs.payu-version }}
     permissions:
       contents: write
     secrets: inherit

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -36,7 +36,8 @@ The configuration properties needed to run the tests are:
 | ---- | ---- | ----------- | -------- |
 | markers | `string` | Markers used for the pytest checks, in the python format | `checksum` |
 | model-config-tests-version | `string` | The version of the model-config-tests | `0.0.1` |
-| python-version | `string` | The python version used to create test virtual environment | `3.11.0` |
+| python-version | `string` | The python version used to create test virtual environment on Github hosted tests | `3.11.0` |
+| payu-version | `string` | The Payu version used to run the model | `1.1.4` |
 
 As most of the tests use the same test and python versions, and similar markers, there are two levels of defaults. There's a default at test type level which is useful for defining test markers - this selects certain pytests to run in `model-config-tests`. There is an outer global default, which is used if a property is not defined for a given branch/tag, and it is not defined for the test default. The `parse-ci-config` action applies the fall-back default logic. For more information on using this action see [`ACCESS-NRI/model-config-tests`](https://github.com/ACCESS-NRI/model-config-tests/).
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -37,7 +37,7 @@ The configuration properties needed to run the tests are:
 | markers | `string` | Markers used for the pytest checks, in the python format | `checksum` |
 | model-config-tests-version | `string` | The version of the model-config-tests | `0.0.1` |
 | python-version | `string` | The python version used to create test virtual environment on Github hosted tests | `3.11.0` |
-| payu-version | `string` | The Payu version used to run the model | `1.1.4` |
+| payu-version | `string` | The Payu version used to run the model | `1.1.5` |
 
 As most of the tests use the same test and python versions, and similar markers, there are two levels of defaults. There's a default at test type level which is useful for defining test markers - this selects certain pytests to run in `model-config-tests`. There is an outer global default, which is used if a property is not defined for a given branch/tag, and it is not defined for the test default. The `parse-ci-config` action applies the fall-back default logic. For more information on using this action see [`ACCESS-NRI/model-config-tests`](https://github.com/ACCESS-NRI/model-config-tests/).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Regarding the secrets and variables that must be created:
 * `secrets.SSH_USER`: A Username to login to the above `HOST`/`HOST_DATA`
 * `vars.DEPLOYMENT_TARGET`: Name of the deployment target for logging purposes (ex. `Supercomputer`)
 * `vars.EXPERIMENTS_LOCATION` - directory on the deployment target that will contain all the experiments used during testing of reproducibility across multiple runs of this workflow (ex. `/scratch/some/directory/experiments`)
+* `vars.MODULE_LOCATION` - directory on the deployment target that contains module files for payu used during reproducibility testing (ex. `/g/data/vk83/modules`)
+* `vars.PRERELEASE_MODULE_LOCATION` - directory on the deployment target that contains module files for development version of payu (ex. `/g/data/vk83/prerelease/modules`)
 
 ### File Modifications
 

--- a/config/ci.json
+++ b/config/ci.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/1-0-0.json",
+    "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "default": {
             "markers": "checksum"
@@ -17,6 +17,7 @@
     },
     "default": {
         "model-config-tests-version": "0.0.1",
-        "python-version": "3.11.0"
+        "python-version": "3.11.0",
+        "payu-version": "1.1.4"
     }
 }

--- a/config/ci.json
+++ b/config/ci.json
@@ -18,6 +18,6 @@
     "default": {
         "model-config-tests-version": "0.0.1",
         "python-version": "3.11.0",
-        "payu-version": "1.1.4"
+        "payu-version": "1.1.5"
     }
 }


### PR DESCRIPTION
In this PR:
* Updated `config/ci.json` schema to `2-0-0` and added global default `payu-version` `1.1.4`
* Update initial generate checksums to use `payu-version`
* Update `README-DEV.md` with `payu-version` and `python-version` usages.
* Update `README.md` with environment variables that need to be set so the `payu` module can be loaded, e.g `vars.MODULE_LOCATION` and `vars.PRERELEASE_MODULE_LOCATION`

Mostly duplicated @CodeGat PR here for updating ACCESS-NRI/access-esm1.5-configs#55

References ACCESS-NRI/model-config-tests#37