### PR TITLE
Add `on.create` Trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: github.event_name == 'push' || (github.event_name == 'create' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: github.event_name == 'push' || (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 run-name: CI (${{ github.event_name }}) for ${{ github.ref_name }}
 on:
+  # For config-pr-1-ci.yml
   pull_request:
     branches:
       - 'release-*'
@@ -13,15 +14,19 @@ on:
       - config/**
       - .*
       - README.md
+  # For config-pr-2-confirm.yml
+  issue_comment:
+    types:
+      - created
+      - edited
+  # For config-pr-3-bump-tag.yml
+  create:
   push:
     branches:
       - 'release-*'
     paths:
       - 'metadata.yaml'
-  issue_comment:
-    types:
-      - created
-      - edited
+
 jobs:
   pr:
     name: PR
@@ -31,7 +36,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write  # For pull request comments denoting failure of the workflow
-      checks: write
+      checks: write  # For results of tests as a check
 
   pr-comment:
     name: Comment
@@ -44,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: github.event_name == 'push' && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: github.event_name == 'push' || (github.event_name == 'create' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: github.event_name == 'push' || (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: (github.event_name == 'push' || github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Each configuration has a `dev-*` and a `release-*` branch. They differ in the CI
 
 ### Dev
 
-The `dev-*` branch is where a configuration is updated. Temporary branches should be created and a pull request made to update the `dev-*` branch. Quality assurance (QA) CI checks are run on pull requests to `dev-*` branches, but not reproducibility checks. There is no requirement that the version be updated when changes are made to the `dev-` branch. So the `dev-` branch of a configuration allows for smaller changes that can be accumulated before a PR is made to the respective `release-*` branch.
+The `dev-*` branch is where a configuration is updated. Temporary branches should be created and a pull request made to update the `dev-*` branch. Quality assurance (QA) CI checks are run on pull requests to `dev-*` branches, but not reproducibility checks. There is no requirement that the version be updated when changes are made to the `dev-` branch - except on the first time that you create the `dev-*` branch. So the `dev-` branch of a configuration allows for smaller changes that can be accumulated before a PR is made to the respective `release-*` branch.
 
 ### Release
 


### PR DESCRIPTION
## Changes

Add a `on.create` trigger for `config-pr-3-bump-tag.yml` for the initial case where we create a `release-*` config branch on top of `dev-*`. Also update some documentation. 

In this PR:
- **ci.yml: Add `on.create` trigger**
- **CONTRIBUTING.md: Update guidance on version bumping**

## Testing

- Boolean logic was verified via truth table
- Verification that `on.create` and `if: github.event_name == 'create' && startsWith(github.ref_name, 'release-')` was enough to push only when a branch like `release-*` was created. See [on creation of release-* branch](https://github.com/codegat-test-org/test/actions/runs/10714023827) and [on creation of non-release-* branch](https://github.com/codegat-test-org/test/actions/runs/10714033435) on my test org. 
- Verified that branches with CI behind `main` _will not have these CI updates_, so we need to cherry pick these changes to other repository branches. 

## References

References ACCESS-NRI/model-config-tests#58
