### PR TITLE
Remove `on.create` Trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ on:
       - created
       - edited
   # For config-pr-3-bump-tag.yml
-  create:
   push:
     branches:
       - 'release-*'
@@ -39,6 +38,7 @@ jobs:
       checks: write  # For results of tests as a check
 
   pr-comment:
+    # Handles `!bump` commands for metadata.yaml
     name: Comment
     if: github.event_name == 'issue_comment' && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-2-confirm.yml@main
@@ -49,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: (github.event_name == 'push' || github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: github.event_name == 'push' && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
       contents: write  # For updating metadata.yaml version and committing checksums
       pull-requests: write  # For commenting on PR
 
+  pr-comment-test:
+    # Handles `!test` commands
+    name: '!test'
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!test') && github.repository != 'ACCESS-NRI/model-configs-template'
+    uses: access-nri/model-config-tests/.github/workflows/config-comment-test.yml@main
+    secrets: inherit
+    permissions:
+      contents: write  # for committing the result of the repro test
+      pull-requests: write  # for writing comments on pull requests
+      checks: write # for adding a status badge next to the commit we are testing
+
   bump-tag:
     name: Tag Bump
     if: github.event_name == 'push' && github.repository != 'ACCESS-NRI/model-configs-template'


### PR DESCRIPTION
References ACCESS-NRI/model-config-tests#92

## Background

Remove the `on.create` trigger because it is interfering with check runs that are done in the first commit in a PR. See the linked issue. 


In this PR:

- ci.yml: Remove `on.create` trigger and references to `create` event for `bump-tag` conditional
- ci.yml: Add `pr-comment-test` job to template
