### PR TITLE
Update CI test markers

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -2,12 +2,12 @@
     "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "default": {
-            "markers": "checksum"
+            "markers": "repro and (not slow)"
         }
     },
     "reproducibility": {
         "default": {
-            "markers": "checksum"
+            "markers": "repro and (not slow)"
         }
     },
     "qa": {
@@ -16,7 +16,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.1",
+        "model-config-tests-version": "0.1.0",
         "python-version": "3.11.0",
         "payu-version": "1.1.5"
     }


### PR DESCRIPTION
This PR updates the version of `model-config-tests` used by the CI and updates the marker names according to https://github.com/ACCESS-NRI/model-config-tests/pull/137.